### PR TITLE
Clear color also on windows - black background

### DIFF
--- a/screensaver.asteroids/addon.xml.in
+++ b/screensaver.asteroids/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.asteroids"
-  version="21.0.0"
+  version="21.0.1"
   name="Asteroids"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,18 +144,15 @@ bool CMyAddon::Start()
 
 ////////////////////////////////////////////////////////////////////////////
 // Kodi tells us to render a frame of our screensaver. This is called on
-// each frame render in Kodi, you should render a single frame only - the DX
-// device will already have been cleared.
+// each frame render in Kodi, you should render a single frame only
 //
 void CMyAddon::Render()
 {
   if (!m_asteroids)
     return;
 
-#ifndef WIN32
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT);
-#endif
 
   Begin();
   m_timer->Update();


### PR DESCRIPTION
Found while making the screensaver window a modeless dialog (https://github.com/xbmc/xbmc/pull/24664) it seems that on windows the background is not forced to black unlike other platforms (https://github.com/xbmc/xbmc/issues/24627#issuecomment-1935512072)